### PR TITLE
Print version, flags for bumping versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,15 @@ fn main() {
     };
 
     let old_version = version.clone();
-    version::update_version(&mut version, conf.version);
-    println!("Version {} -> {}", old_version, version);
+    if let Some(new_version) = conf.version {
+        version::update_version(&mut version, new_version);
+    }
+
+    if conf.print_version_only {
+        println!("{}", version);
+    } else {
+        println!("Version {} -> {}", old_version, version);
+    }
 
     parser.set_value(
         "package.version",


### PR DESCRIPTION
I need to read the crate version for use in a build script, and parsing of `{} -> {}` is inconvenient, so I've added `--print` that does that. 

I've expected `major`/`minor`/`patch` to be command line flags, like `--major`/`--minor`/`--patch`, so I've added that (existing syntax is still supported).

`cargo bump --print` just prints the old version without bumping, `cargo bump --print --minor` bumps and then prints the new version.

