### PR TITLE
pre-release and build metadata as options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,7 +1,10 @@
 [[package]]
 name = "ansi_term"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ascii"
@@ -10,12 +13,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atty"
-version = "0.2.2"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -47,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -60,8 +63,8 @@ name = "cargo-bump"
 version = "1.0.2"
 dependencies = [
  "cargo_metadata 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml_edit 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -99,18 +102,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.26.0"
+version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -142,15 +143,6 @@ dependencies = [
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
@@ -186,7 +178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -194,16 +186,24 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -214,14 +214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ryu"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "semver"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "semver"
@@ -247,8 +239,8 @@ name = "serde_derive"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -264,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -272,28 +264,27 @@ name = "syn"
 version = "0.15.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.0"
+name = "termion"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -302,7 +293,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -317,13 +308,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-width"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -341,17 +327,12 @@ dependencies = [
 
 [[package]]
 name = "vec_map"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "void"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -364,11 +345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,54 +355,50 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5fc969a8ce2c9c0c4b0429bb8431544f6658283c8326ba5ff8c762b75369335"
-"checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60f0b0d4c0a382d2734228fd12b5a6b5dac185c60e938026fd31b265b94f9bd2"
 "checksum cargo_metadata 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95932a7ed5f2308fc00a46d2aa8eb1b06b402c896c2df424916ee730ba610c2e"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
+"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum combine 3.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3d64b57f9d8186d72311c241e580409b31e5d340c67fd2d9c74f05eda6d3aa54"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)" = "48450664a984b25d5b479554c29cc04e3150c97aa4c01da5604a2d4ed9151476"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
-"checksum proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)" = "d3797b7142c9aa74954e351fc089bbee7958cebbff6bf2815e7ffff0b19f547d"
-"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
-"checksum redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)" = "52ee9a534dc1301776eff45b4fa92d2c39b1d8c3d3357e6eb593e0d795506fc2"
+"checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fdd61b85a0fa777f7fb7c454b9189b2941b110d1385ce84d7f76efdf1606a85"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "534b8b91a95e0f71bca3ed5824752d558da048d4248c91af873b63bd60519752"
 "checksum serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "a915306b0f1ac5607797697148c223bedeaa36bcc2e28a01441cd638cc6567b4"
 "checksum serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "574378d957d6dcdf1bbb5d562a15cbd5e644159432f84634b94e485267abbcc7"
-"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
-"checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
-"checksum textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f728584ea33b0ad19318e20557cb0a39097751dbb07171419673502f848c7af6"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml_edit 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "49f417ffef0480dcd2db983b67b4d07c49147da72b4c3b65db0348f5cfccb929"
-"checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
-"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ travis-ci = {repository = "wraithan/cargo-bump", branch = "master" }
 
 [dependencies]
 clap = "2.26.0"
-semver = "0.7.0"
+semver = "0.9.0"
 toml_edit = "0.1.3"
 cargo_metadata = "0.7.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,11 +15,18 @@ fn build_cli_parser<'a, 'b>() -> App<'a, 'b> {
     App::new("cargo-bump")
         .version(VERSION)
         .author("Wraithan McCarroll <xwraithanx@gmail.com>")
-        .usage("cargo bump [FLAGS] [<version> | major | minor | patch]")
+        .usage(
+            "cargo bump [<version> | major | minor | patch] [FLAGS]
+
+    Version parts: ${MAJOR}.${MINOR}.${PATCH}-${PRE-RELEASE}+${BUILD}
+    Example: 3.1.4-alpha+159",
+        )
         .about("Increments the version number in Cargo.toml as specified.")
         .setting(AppSettings::ArgRequiredElseHelp)
         .version_short("v")
         .arg(
+            // This is because when we're called from cargo,
+            // our first arg is the command we were calld as.
             Arg::with_name("bump")
                 .possible_value("bump")
                 .index(1)
@@ -30,7 +37,8 @@ fn build_cli_parser<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("manifest-path")
                 .long("manifest-path")
                 .value_name("PATH")
-                .takes_value(true),
+                .takes_value(true)
+                .help("Optional path to Cargo.toml"),
         )
         .arg(Arg::with_name("version").index(2).help(
             "Version should be a semver (https://semver.org/) string or the \
@@ -40,31 +48,31 @@ fn build_cli_parser<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("pre-release")
                 .short("p")
                 .long("pre-release")
+                .value_name("RELEASE TYPE")
                 .takes_value(true)
                 .help("Optional pre-release information."),
         )
         .arg(
-            Arg::with_name("metadata")
-                .short("m")
-                .long("metadata")
+            Arg::with_name("build-metadata")
+                .short("b")
+                .long("build")
+                .value_name("BUILD")
                 .takes_value(true)
-                .help("Optional metadata for this version."),
+                .help("Optional build metadata for this version."),
         )
 }
 
-#[derive(Debug, PartialEq)]
 pub struct Config {
-    pub version: NewVersion,
-    pub metadata: Option<Vec<Identifier>>,
-    pub pre_release: Option<Vec<Identifier>>,
-
+    pub version_modifier: VersionModifier,
     pub manifest: PathBuf,
 }
 
 impl Config {
     fn from_matches(matches: ArgMatches) -> Config {
-        let version = NewVersion::from_str(matches.value_of("version").unwrap_or("patch"))
+        let mod_type = ModifierType::from_str(matches.value_of("version").unwrap_or("patch"))
             .expect("Invalid semver version, expected version or major, minor, patch");
+        let build_metadata = matches.value_of("build-metadata").map(parse_identifiers);
+        let pre_release = matches.value_of("pre-release").map(parse_identifiers);
 
         let mut metadata_cmd = MetadataCommand::new();
         if let Some(path) = matches.value_of("manifest-path") {
@@ -73,9 +81,11 @@ impl Config {
         let metadata = metadata_cmd.exec().expect("get cargo metadata");
         if metadata.workspace_members.len() == 1 {
             Config {
-                version,
-                metadata: matches.value_of("metadata").map(parse_identifiers),
-                pre_release: matches.value_of("pre-release").map(parse_identifiers),
+                version_modifier: VersionModifier {
+                    mod_type,
+                    build_metadata,
+                    pre_release,
+                },
                 manifest: metadata[&metadata.workspace_members[0]]
                     .manifest_path
                     .clone(),
@@ -100,57 +110,112 @@ fn parse_identifiers(value: &str) -> Vec<Identifier> {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum NewVersion {
+pub enum ModifierType {
     Replace(Version),
     Major,
     Minor,
     Patch,
 }
 
-impl FromStr for NewVersion {
+impl FromStr for ModifierType {
     type Err = SemVerError;
-    fn from_str(input: &str) -> Result<NewVersion, Self::Err> {
+    fn from_str(input: &str) -> Result<ModifierType, Self::Err> {
         Ok(match input {
-            "major" => NewVersion::Major,
-            "minor" => NewVersion::Minor,
-            "patch" => NewVersion::Patch,
-            _ => NewVersion::Replace(Version::parse(input)?),
+            "major" => ModifierType::Major,
+            "minor" => ModifierType::Minor,
+            "patch" => ModifierType::Patch,
+            _ => ModifierType::Replace(Version::parse(input)?),
         })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct VersionModifier {
+    pub mod_type: ModifierType,
+    pub build_metadata: Option<Vec<Identifier>>,
+    pub pre_release: Option<Vec<Identifier>>,
+}
+
+impl VersionModifier {
+    #[allow(unused)]
+    pub fn new(
+        mod_type: ModifierType,
+        pre_release: Option<&str>,
+        build_metadata: Option<&str>,
+    ) -> Self {
+        Self {
+            mod_type,
+            build_metadata: build_metadata.map(parse_identifiers),
+            pre_release: pre_release.map(parse_identifiers),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn from_mod_type(mod_type: ModifierType) -> Self {
+        Self {
+            mod_type,
+            build_metadata: None,
+            pre_release: None,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_cli_parser, Config, NewVersion};
-    use semver::Version;
+    use super::*;
     use std::env;
 
-    fn test_config(input: Vec<&str>, version: NewVersion) {
+    fn test_config(input: Vec<&str>, version_mod: VersionModifier) {
         let parser = build_cli_parser();
         let root = env::current_dir().unwrap();
         let mut manifest = root.clone();
         manifest.push("Cargo.toml");
         let matches = parser.get_matches_from_safe(input).unwrap();
         let config = Config::from_matches(matches);
-        assert_eq!(config.version, version);
+        assert_eq!(config.version_modifier, version_mod);
         assert_eq!(config.manifest, manifest);
     }
 
     #[test]
     fn bump_arg_only() {
         let input = vec!["cargo-bump", "bump"];
-        test_config(input, NewVersion::Patch)
+        test_config(input, VersionModifier::from_mod_type(ModifierType::Patch))
     }
 
     #[test]
     fn version_arg_minor() {
         let input = vec!["cargo-bump", "bump", "minor"];
-        test_config(input, NewVersion::Minor)
+        test_config(input, VersionModifier::from_mod_type(ModifierType::Minor))
     }
 
     #[test]
     fn version_arg_string_good() {
         let input = vec!["cargo-bump", "bump", "1.2.3"];
-        test_config(input, NewVersion::Replace(Version::parse("1.2.3").unwrap()))
+        test_config(
+            input,
+            VersionModifier::from_mod_type(ModifierType::Replace(Version::parse("1.2.3").unwrap())),
+        )
+    }
+
+    #[test]
+    fn version_bump_and_build() {
+        let input = vec!["cargo-bump", "bump", "major", "--build", "1999"];
+        let version_mod = VersionModifier {
+            mod_type: ModifierType::Major,
+            build_metadata: Some(vec![Identifier::Numeric(1999)]),
+            pre_release: None,
+        };
+        test_config(input, version_mod);
+    }
+
+    #[test]
+    fn version_bump_and_pre() {
+        let input = vec!["cargo-bump", "bump", "2.0.0", "--pre-release", "beta"];
+        let version_mod = VersionModifier {
+            mod_type: ModifierType::Replace(Version::parse("2.0.0").unwrap()),
+            build_metadata: None,
+            pre_release: Some(vec![Identifier::AlphaNumeric(String::from("beta"))]),
+        };
+        test_config(input, version_mod);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn update_toml_with_version(raw_data: &str, version_modifier: config::NewVersion
         let mut version = version_string
             .parse::<Version>()
             .expect("version is semver");
-        version::update_version(&mut version, version_modifier);
+        version::update_version(&mut version, version_modifier, None, None);
         version
     };
     value["package"]["version"] = toml_edit::value(version.to_string());

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,31 +1,26 @@
-use config::NewVersion;
-use semver::{Identifier, Version};
+use config::{ModifierType, VersionModifier};
+use semver::Version;
 
-pub fn update_version(
-    old: &mut Version,
-    by: NewVersion,
-    pre_release: Option<Vec<Identifier>>,
-    metadata: Option<Vec<Identifier>>,
-) {
-    match by {
-        NewVersion::Replace(v) => {
+pub fn update_version(old: &mut Version, by: VersionModifier) {
+    match by.mod_type {
+        ModifierType::Replace(v) => {
             *old = v;
         }
-        NewVersion::Major => {
+        ModifierType::Major => {
             old.increment_major();
         }
-        NewVersion::Minor => {
+        ModifierType::Minor => {
             old.increment_minor();
         }
-        NewVersion::Patch => {
+        ModifierType::Patch => {
             old.increment_patch();
         }
     }
 
-    if let Some(pre) = pre_release {
+    if let Some(pre) = by.pre_release {
         old.pre = pre;
     }
-    if let Some(build) = metadata {
+    if let Some(build) = by.build_metadata {
         old.build = build;
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,7 +1,12 @@
 use config::NewVersion;
-use semver::Version;
+use semver::{Identifier, Version};
 
-pub fn update_version(old: &mut Version, by: NewVersion) {
+pub fn update_version(
+    old: &mut Version,
+    by: NewVersion,
+    pre_release: Option<Vec<Identifier>>,
+    metadata: Option<Vec<Identifier>>,
+) {
     match by {
         NewVersion::Replace(v) => {
             *old = v;
@@ -15,5 +20,12 @@ pub fn update_version(old: &mut Version, by: NewVersion) {
         NewVersion::Patch => {
             old.increment_patch();
         }
+    }
+
+    if let Some(pre) = pre_release {
+        old.pre = pre;
+    }
+    if let Some(build) = metadata {
+        old.build = build;
     }
 }


### PR DESCRIPTION
This takes from #9, I've taken a good number of liberties with the patch.

I only pulled in the options, not the library switch code, that is explained in the comment section of #9.

I had refactored the application of the options to the TOML file into a function so I had to update the original patch to reflect that. I didn't want to have to thread a lot values through the system separately that would always be used together, so I left the patch in a not working state.

The second commit on this PR includes a refactor, tests, and wiring up the config to the end TOML generation. I renamed the `--metadata` option to `--build` to match the underlying `semver` crate and spec better. 

The primary goal of the refactor was to group up the options used in updating the TOML vs loading the TOML. I created a `VersionModifier` struct that contains the `ModifierType` enum (used to be `NewVersion`) as well as the optional pre-release and build metadata. This let me lower the number of args to a few functions. Along the way I added tests to ensure the pre-release and build metadata options work, which included adding a few functions to make the structs more testable.