### PR TITLE
update lock file as well as cargo.toml

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,7 @@ pub struct Config {
     pub version_modifier: VersionModifier,
     pub manifest: PathBuf,
     pub git_tag: bool,
+    pub lock_file: PathBuf,
 }
 
 impl Config {
@@ -86,6 +87,10 @@ impl Config {
             metadata_cmd.manifest_path(path);
         }
         let metadata = metadata_cmd.exec().expect("get cargo metadata");
+        let manifest = metadata[&metadata.workspace_members[0]]
+            .manifest_path
+            .clone();
+        let lock_file = manifest.with_extension("lock");
         if metadata.workspace_members.len() == 1 {
             Config {
                 version_modifier: VersionModifier {
@@ -93,10 +98,9 @@ impl Config {
                     build_metadata,
                     pre_release,
                 },
-                manifest: metadata[&metadata.workspace_members[0]]
-                    .manifest_path
-                    .clone(),
+                manifest,
                 git_tag,
+                lock_file,
             }
         } else {
             panic!("Workspaces are not supported yet.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,13 +19,15 @@ use semver::Version;
 fn main() {
     let conf = config::get_config();
     let raw_data = read_file(&conf.manifest);
+    let raw_lock_data = read_file(&conf.lock_file);
     let use_git = conf.git_tag;
 
     if use_git {
         git::git_check();
     }
 
-    let output = update_toml_with_version(&raw_data, conf.version_modifier);
+    let (output, lock_output) =
+        update_toml_with_version(&raw_data, &raw_lock_data, conf.version_modifier);
     let version = output["package"]["version"].as_str().unwrap();
 
     let mut f = OpenOptions::new()
@@ -34,6 +36,13 @@ fn main() {
         .open(&conf.manifest)
         .unwrap();
     f.write_all(output.to_string().as_bytes()).unwrap();
+
+    let mut fl = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&conf.lock_file)
+        .unwrap();
+    fl.write_all(lock_output.to_string().as_bytes()).unwrap();
 
     if use_git {
         git::git_commit_and_tag(version);
@@ -47,7 +56,11 @@ fn read_file(file: &Path) -> String {
     raw_data
 }
 
-fn update_toml_with_version(raw_data: &str, version_modifier: config::VersionModifier) -> Document {
+fn update_toml_with_version(
+    raw_data: &str,
+    raw_lock_data: &str,
+    version_modifier: config::VersionModifier,
+) -> (Document, Document) {
     let mut value = raw_data
         .parse::<toml_edit::Document>()
         .expect("parsed toml");
@@ -62,8 +75,20 @@ fn update_toml_with_version(raw_data: &str, version_modifier: config::VersionMod
         version
     };
     value["package"]["version"] = toml_edit::value(version.to_string());
+    let package_name = value["package"]["name"].as_str().unwrap();
 
-    value
+    let mut lock_value = raw_lock_data
+        .parse::<toml_edit::Document>()
+        .expect("parsed lock file");
+    {
+        let lock_table = lock_value["package"].as_array_of_tables_mut().unwrap();
+        let idx = lock_table
+            .iter()
+            .position(|val| val["name"].as_str().unwrap_or("") == package_name)
+            .unwrap();
+        lock_table.get_mut(idx).unwrap()["version"] = toml_edit::value(version.to_string());
+    }
+    (value.clone(), lock_value)
 }
 
 #[cfg(test)]
@@ -73,27 +98,41 @@ mod test {
 
     fn toml_test_wrapper(
         template: &str,
+        lock_template: &str,
         version_modifier: VersionModifier,
         start_version: &str,
         end_version: &str,
     ) {
         let input = template.replace("$VERSION", &format!("\"{}\"", start_version));
         let expected_output = template.replace("$VERSION", &format!("\"{}\"", end_version));
-        let output = update_toml_with_version(&input, version_modifier);
+        let lock_input = lock_template.replace("$VERSION", &format!("\"{}\"", start_version));
+        let expected_lock_output =
+            lock_template.replace("$VERSION", &format!("\"{}\"", end_version));
+        let (output, lock_output) = update_toml_with_version(&input, &lock_input, version_modifier);
         assert_eq!(
             expected_output,
             output.to_string().trim_end(),
             "toml output should be same with new version"
+        );
+        assert_eq!(
+            expected_lock_output,
+            lock_output.to_string().trim_end(),
+            "toml.lock output should be same with new version"
         );
     }
 
     #[test]
     fn toml_test_simple() {
         let input = "[package]
-version = $VERSION";
+            name = \"cargo-bump\"
+            version = $VERSION";
+        let lock_input = "[[package]]
+            name = \"cargo-bump\"
+            version = $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.0",
@@ -101,6 +140,7 @@ version = $VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.1",
@@ -108,6 +148,7 @@ version = $VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.1.0",
@@ -115,12 +156,13 @@ version = $VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "2.0.0",
         );
         let version_mod = VersionModifier::new(ModifierType::Major, Some("RC"), None);
-        toml_test_wrapper(input, version_mod, "1.0.0", "2.0.0-RC");
+        toml_test_wrapper(input, lock_input, version_mod, "1.0.0", "2.0.0-RC");
         let version_mod = VersionModifier::new(
             ModifierType::Major,
             None,
@@ -128,21 +170,27 @@ version = $VERSION";
         );
         toml_test_wrapper(
             input,
+            lock_input,
             version_mod,
             "1.0.0",
             "2.0.0+ac44f1f8f31acf4728bd2055d716776b",
         );
         let version_mod = VersionModifier::new(ModifierType::Major, Some("alpha"), Some("2230"));
-        toml_test_wrapper(input, version_mod, "1.0.0", "2.0.0-alpha+2230");
+        toml_test_wrapper(input, lock_input, version_mod, "1.0.0", "2.0.0-alpha+2230");
     }
 
     #[test]
     fn toml_test_formatting_preserved_spaces() {
-        let input = "  [package]
-    version = $VERSION";
+        let input = "[package]
+            name = \"cargo-bump\"
+            version = $VERSION";
+        let lock_input = "[[package]]
+            name = \"cargo-bump\"
+            version = $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.0.0",
@@ -150,6 +198,7 @@ version = $VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.1.1",
@@ -157,6 +206,7 @@ version = $VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.2.0",
@@ -164,16 +214,22 @@ version = $VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "2.0.0",
         );
 
         let input = "  [package]
+name = \"cargo-bump\"
+version= $VERSION";
+        let lock_input = "  [[package]]
+name = \"cargo-bump\"
 version= $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.0.0",
@@ -181,6 +237,7 @@ version= $VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.1.1",
@@ -188,6 +245,7 @@ version= $VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.2.0",
@@ -195,16 +253,22 @@ version= $VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "2.0.0",
         );
 
         let input = "  [package]
+name          = \"cargo-bump\"
+version       = $VERSION";
+        let lock_input = "  [[package]]
+name          = \"cargo-bump\"
 version       = $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.0.0",
@@ -212,6 +276,7 @@ version       = $VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.1.1",
@@ -219,6 +284,7 @@ version       = $VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.2.0",
@@ -226,6 +292,7 @@ version       = $VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "2.0.0",
@@ -236,10 +303,15 @@ version       = $VERSION";
     #[ignore = "toml_edit doesn't expose enough to preserve whitespace around replaced string"]
     fn toml_test_formatting_preserved_space_around_replaced_value() {
         let input = "  [package]
+name =\"cargo-bump\"
+version =$VERSION";
+        let lock_input = "  [[package]]
+name =\"cargo-bump\"
 version =$VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.0.0",
@@ -247,6 +319,7 @@ version =$VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.1.1",
@@ -254,6 +327,7 @@ version =$VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.2.0",
@@ -261,16 +335,22 @@ version =$VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "2.0.0",
         );
 
         let input = "  [package]
+name =       \"cargo-bump\"
+version =    $VERSION";
+        let lock_input = "  [[package]]
+name =       \"cargo-bump\"
 version =    $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.0.0",
@@ -278,6 +358,7 @@ version =    $VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.1.1",
@@ -285,6 +366,7 @@ version =    $VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.2.0",
@@ -292,16 +374,22 @@ version =    $VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "2.0.0",
         );
 
         let input = "  [package]
+name = \"cargo-bump\"       
+version = $VERSION      ";
+        let lock_input = "  [[package]]
+name = \"cargo-bump\"       
 version = $VERSION      ";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.0.0",
@@ -309,6 +397,7 @@ version = $VERSION      ";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.1.1",
@@ -316,6 +405,7 @@ version = $VERSION      ";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.2.0",
@@ -323,6 +413,7 @@ version = $VERSION      ";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "2.0.0",
@@ -333,12 +424,19 @@ version = $VERSION      ";
     #[ignore = "toml_edit doesn't handle preserving space in headers save test for later"]
     fn toml_test_formatting_preserved_header_spaces() {
         let input = "  [package]
+        name = \"cargo-bump\"
+    version = $VERSION
+[     other]
+a = true";
+        let lock_input = "  [[package]]
+        name = \"cargo-bump\"
     version = $VERSION
 [     other]
 a = true";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.0.0",
@@ -346,6 +444,7 @@ a = true";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.1.1",
@@ -353,6 +452,7 @@ a = true";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "1.2.0",
@@ -360,16 +460,22 @@ a = true";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.0",
             "2.0.0",
         );
 
         let input = "  [  package   ]
+        name = \"cargo-bump\"
+    version= $VERSION";
+        let lock_input = "  [[  package   ]]
+        name = \"cargo-bump\"
     version= $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.1",
             "1.0.0",
@@ -377,6 +483,7 @@ a = true";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.1",
             "1.1.2",
@@ -384,6 +491,7 @@ a = true";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.1",
             "1.2.0",
@@ -391,6 +499,7 @@ a = true";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.1.1",
             "2.0.0",
@@ -399,6 +508,17 @@ a = true";
         let input = "  [  package   ]
 
 
+            
+            name=\"cargo-bump\"
+
+    version= $VERSION
+    
+    ";
+        let lock_input = "  [[  package   ]]
+
+
+            
+            name=\"cargo-bump\"
 
     version= $VERSION
     
@@ -406,6 +526,7 @@ a = true";
         let mod_type = "4.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "2.0.0",
             "4.0.0",
@@ -413,6 +534,7 @@ a = true";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "2.0.0",
             "2.0.1",
@@ -420,6 +542,7 @@ a = true";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "2.0.0",
             "2.1.0",
@@ -427,6 +550,7 @@ a = true";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "2.0.0",
             "3.0.0",
@@ -437,10 +561,16 @@ a = true";
     fn toml_test_formatting_preserved_comments() {
         let input = "#before header
 [package]
+name = \"cargo-bump\"
+version = $VERSION";
+        let lock_input = "#before header
+[[package]]
+name = \"cargo-bump\"
 version = $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.0",
@@ -448,6 +578,7 @@ version = $VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.1",
@@ -455,6 +586,7 @@ version = $VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.1.0",
@@ -462,16 +594,22 @@ version = $VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "2.0.0",
         );
 
         let input = "[package]# end of header
+name = \"cargo-bump\"
+version = $VERSION";
+        let lock_input = "[[package]]# end of header
+name = \"cargo-bump\"
 version = $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.0",
@@ -479,6 +617,7 @@ version = $VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.1",
@@ -486,6 +625,7 @@ version = $VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.1.0",
@@ -493,17 +633,24 @@ version = $VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "2.0.0",
         );
 
         let input = "[package]
+name = \"cargo-bump\"
+# version = \"2.0.0\"
+version = $VERSION";
+        let lock_input = "[[package]]
+name = \"cargo-bump\"
 # version = \"2.0.0\"
 version = $VERSION";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.0",
@@ -511,6 +658,7 @@ version = $VERSION";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.1",
@@ -518,6 +666,7 @@ version = $VERSION";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.1.0",
@@ -525,6 +674,7 @@ version = $VERSION";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "2.0.0",
@@ -534,6 +684,16 @@ version = $VERSION";
     #[test]
     fn toml_test_dotted_headers() {
         let input = "[package]
+name = \"cargo-bump\"
+version = $VERSION
+
+[a]
+d = false
+
+[a.b]
+c = true";
+        let lock_input = "[[package]]
+name = \"cargo-bump\"
 version = $VERSION
 
 [a]
@@ -544,6 +704,7 @@ c = true";
         let mod_type = "1.0.0".parse().expect("version modifier");
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.0",
@@ -551,6 +712,7 @@ c = true";
         let mod_type = ModifierType::Patch;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.0.1",
@@ -558,6 +720,7 @@ c = true";
         let mod_type = ModifierType::Minor;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "1.1.0",
@@ -565,6 +728,7 @@ c = true";
         let mod_type = ModifierType::Major;
         toml_test_wrapper(
             input,
+            lock_input,
             VersionModifier::from_mod_type(mod_type),
             "1.0.0",
             "2.0.0",


### PR DESCRIPTION
previously you needed to do `cargo run` to update the `Cargo.lock` file with the new version number after running `cargo bump VERSION`. this does it all in one go.

I'm not super pleased with my changes to the  `update_toml_with_version` function, but i wasn't sure of a different/better way to do it because of the nested nature of the lock file. i could break it out into it's own separate function, but im not sure how much that would improve things if at all.