### PR TITLE
Add rudimentary support for workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-bump"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "cargo_metadata 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "ISC"
 name = "cargo-bump"
 readme = "README.md"
 repository = "https://github.com/wraithan/cargo-bump"
-version = "1.1.0"
+version = "1.2.0"
 
 [badges]
 travis-ci = {repository = "wraithan/cargo-bump", branch = "master" }


### PR DESCRIPTION
This adds quick and dirty support for workspaces.

It Reads in workspace members and iterates through all of them, updating
the version according to the VersionModifier policy.

There are some issues with the approach as implemented:
* If git-tag is enabled, and different crates have different versions,
  then the tag is created with the last updated version. This isn't
  ideal if the member crates have different versions, but then what would
  you use to tag the git commit with in this case? We'd need to add
  some sort of "git strategy" to handle these cases, which is outside the scope
  of this PR.
* If there are inter-crate dependencies within the workspace, the dependency versions
  are not updated, which can cause a panic. Fixing this is also out of the scope of this
  PR