### PR TITLE
run_build option to fix issues with Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
  "cargo_metadata 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml_edit 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml_edit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -94,9 +94,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -118,13 +119,13 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "3.6.6"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -153,17 +154,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.1.3"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num-integer"
@@ -301,12 +298,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "combine 3.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -368,15 +365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cargo_metadata 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95932a7ed5f2308fc00a46d2aa8eb1b06b402c896c2df424916ee730ba610c2e"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
-"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum combine 3.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3d64b57f9d8186d72311c241e580409b31e5d340c67fd2d9c74f05eda6d3aa54"
+"checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)" = "48450664a984b25d5b479554c29cc04e3150c97aa4c01da5604a2d4ed9151476"
-"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
-"checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
+"checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
@@ -395,7 +392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum toml_edit 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "49f417ffef0480dcd2db983b67b4d07c49147da72b4c3b65db0348f5cfccb929"
+"checksum toml_edit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87f53b1aca7d5fe2e17498a38cac0e1f5a33234d5b980fb36b9402bb93b98ae4"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ travis-ci = {repository = "wraithan/cargo-bump", branch = "master" }
 [dependencies]
 clap = "2.26.0"
 semver = "0.9.0"
-toml_edit = "0.1.3"
+toml_edit = "0.1.5"
 cargo_metadata = "0.7.0"

--- a/README.md
+++ b/README.md
@@ -26,14 +26,25 @@ Set the version number directly: `cargo bump 13.3.7`
 
 ```
 USAGE:
-    cargo bump [FLAGS] [<version> | major | minor | patch]
+    cargo bump [<version> | major | minor | patch] [FLAGS]
+
+    Version parts: ${MAJOR}.${MINOR}.${PATCH}-${PRE-RELEASE}+${BUILD}
+    Example: 3.1.4-alpha+159
 
 FLAGS:
-    -h, --help       Prints help information
-    -v, --version    Prints version information
-    -g, --git-tag    Commits the new version and creates a git tag
+    -g, --git-tag     Optional commit the updated version and create a git tag.
+    -h, --help        Prints help information
+    -r, --run-buid    Optional run `cargo build` before handling any git logic.
+                                      This has the added benefit of fixing the Cargo.lock before the git commits are
+                      made.
+    -v, --version     Prints version information
+
+OPTIONS:
+    -b, --build <BUILD>                 Optional build metadata for this version.
+        --manifest-path <PATH>          Optional path to Cargo.toml
+    -p, --pre-release <RELEASE TYPE>    Optional pre-release information.
 
 ARGS:
-    <version>    Version should be a semver (https://semver.org/) string or the
-                 position of the current version to increment: major, minor or patch.
+    <version>    Version should be a semver (https://semver.org/) string or the position of the current version to
+                 increment: major, minor or patch.
 ```

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,9 @@
+use std::process::Command;
+
+pub fn run() {
+    let output = Command::new("cargo").args(&["build"]).output().unwrap();
+
+    if !output.status.success() {
+        panic!("Bumping the version caused cargo build to fail. Stopping any further actions.");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,12 +66,20 @@ fn build_cli_parser<'a, 'b>() -> App<'a, 'b> {
                 .long("git-tag")
                 .help("Optional commit the updated version and create a git tag."),
         )
+        .arg(
+            Arg::with_name("run-build")
+                .short("r")
+                .long("run-buid")
+                .help("Optional run `cargo build` before handling any git logic.
+                This has the added benefit of fixing the Cargo.lock before the git commits are made."),
+        )
 }
 
 pub struct Config {
     pub version_modifier: VersionModifier,
     pub manifest: PathBuf,
     pub git_tag: bool,
+    pub run_build: bool,
 }
 
 impl Config {
@@ -81,6 +89,7 @@ impl Config {
         let build_metadata = matches.value_of("build-metadata").map(parse_identifiers);
         let pre_release = matches.value_of("pre-release").map(parse_identifiers);
         let git_tag = matches.is_present("git-tag");
+        let run_build = matches.is_present("run-build");
         let mut metadata_cmd = MetadataCommand::new();
         if let Some(path) = matches.value_of("manifest-path") {
             metadata_cmd.manifest_path(path);
@@ -97,6 +106,7 @@ impl Config {
                     .manifest_path
                     .clone(),
                 git_tag,
+                run_build,
             }
         } else {
             panic!("Workspaces are not supported yet.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ extern crate clap;
 extern crate semver;
 extern crate toml_edit;
 
+mod build;
 mod config;
 mod git;
 mod version;
@@ -20,6 +21,7 @@ fn main() {
     let conf = config::get_config();
     let raw_data = read_file(&conf.manifest);
     let use_git = conf.git_tag;
+    let run_build = conf.run_build;
 
     if use_git {
         git::git_check();
@@ -34,6 +36,10 @@ fn main() {
         .open(&conf.manifest)
         .unwrap();
     f.write_all(output.to_string().as_bytes()).unwrap();
+
+    if run_build {
+        build::run();
+    }
 
     if use_git {
         git::git_commit_and_tag(version);


### PR DESCRIPTION
When running with the git tag option, the Cargo.lock file is not updated. This results in a situation where on the next `cargo build` the Carco.lock file will be updated with the new version. To get these to be updated in the same commit, we can run `cargo build` beforehand which will update anything in the Cargo.lock that's required. It also has a small side effect of ensuring that the Cargo.toml file has not been modified in such a way to break the build.

Adding this as an options makes this a backwards compatible change.